### PR TITLE
Update zn.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Termux-ZeroNet
+ZeroNet Bootstrap Script for Termux (Android App)
+
+This fork was an attempt to fix the issues with the original script. 
+
+To use this, simply download Termux and get the zn.sh file onto your phone. 
+
+You can use any method to upload the zn.sh file onto your phone, but you might have to run termux-setup-storage to navigate to if
+
+you can't figure out how to. Afterwards, run bash zn.sh and the script will install all the needed dependencies for Zeronet and
+
+begin running the service. Now all you have to do is open your browser and navigate to a Zeronet page to get started. 

--- a/zn.sh
+++ b/zn.sh
@@ -3,19 +3,23 @@
 if [[ -z "$ZERONET_HOME" ]]; then
 	echo "--- Installing ZeroNet ---"
 	termux-setup-storage
-	apt-get -y update && apt-get -y upgrade
-	apt-get install -y curl make python2-dev git gcc grep c-ares-dev libev-dev openssl-tool
+	apt-get -y update && apt-get -y upgrade 
+	apt install clang -y 
+	apt-get install -y curl make python2-dev git clang grep c-ares-dev libev-dev openssl-tool
 	export LIBEV_EMBED=false
 	export CARES_EMBED=false
+	pip2 install --upgrade pip && pip2 install https://github.com/fornwall/greenlet/archive/master.zip
+	EMBED=0 pip2 install gevent
 	pip2 install gevent msgpack-python
 
-	if [[ ! -d ~/storage/shared/ZeroNet ]]; then
-		mkdir ~/storage/shared/ZeroNet
-		git clone https://github.com/HelloZeroNet/ZeroNet.git ~/storage/shared/ZeroNet
+	if [[ ! -d ~/ZeroNet ]]; then
+		cd ~
+		curl -L https://github.com/HelloZeroNet/ZeroNet/archive/master.tar.gz | tar xz
+		mv ~/ZeroNet-master ~/ZeroNet
+
 	fi
 
-	cp "$0" ~/zn.sh
-	echo 'export ZERONET_HOME=~/storage/shared/ZeroNet' >> ~/.bashrc
+	echo 'export ZERONET_HOME=~/ZeroNet' >> ~/.bashrc
 	echo "alias zn=\"bash ~/zn.sh\"" >> ~/.bashrc
 	source ~/.bashrc
 


### PR DESCRIPTION
I recently found your repository and tried it out with Termux, but when I tried running the script as it was, I ran into several issues. 
1. gcc had been replaced by clang
2. the pip2 install for gevent/greenlet/msgpack wasn't working due to an error with greenlet. 
3. The directory that was originally being drawn in wouldn't actually let me run Zeronet as I kept getting an error when the python2 zeronet.py was started. 

I found workarounds for all the issues and then pulled in the master.tar.gz suggested for the zeronet Debian install instructions. Otherwise all the rest of the script was kept the same. There are still some issues with specific sites when running Zeronet through this Termux setup that I haven't had when setting it up using GNURoot. However, the installation will run and you can access Zeronet now.