### PR TITLE
Fixing gevent install (and other improvements)

### DIFF
--- a/zn.sh
+++ b/zn.sh
@@ -4,15 +4,12 @@ if [[ -z "$ZERONET_HOME" ]]; then
 	echo "--- Installing ZeroNet ---"
 	termux-setup-storage
 	apt-get -y update && apt-get -y upgrade 
-	apt install clang -y 
 	apt-get install -y curl make python2-dev git clang grep c-ares-dev libev-dev openssl-tool
 	export LIBEV_EMBED=false
 	export CARES_EMBED=false
 	export CONFIG_SHELL=$PREFIX/bin/sh
 	export TMPDIR=$PREFIX/tmp
-	pip2 install --upgrade pip && pip2 install https://github.com/fornwall/greenlet/archive/master.zip
-	EMBED=0 pip2 install gevent
-	pip2 install gevent msgpack-python
+	EMBED=0 pip2 install gevent msgpack-python
 
 	if [[ ! -d ~/ZeroNet ]]; then
 		cd ~

--- a/zn.sh
+++ b/zn.sh
@@ -8,6 +8,8 @@ if [[ -z "$ZERONET_HOME" ]]; then
 	apt-get install -y curl make python2-dev git clang grep c-ares-dev libev-dev openssl-tool
 	export LIBEV_EMBED=false
 	export CARES_EMBED=false
+	export CONFIG_SHELL=$PREFIX/bin/sh
+	export TMPDIR=$PREFIX/tmp
 	pip2 install --upgrade pip && pip2 install https://github.com/fornwall/greenlet/archive/master.zip
 	EMBED=0 pip2 install gevent
 	pip2 install gevent msgpack-python


### PR DESCRIPTION
Hi. I came across this script recently and ran into errors while installing gevent. In order to make it work, I had to add the workaround in the first commit ([c1b7c31](https://github.com/WillyPillow/Termux-ZeroNet/commit/c1b7c3126e856264395577206622c3bd95f30cc4)).

Also, I cleaned up some lines that were doing the same things, and removed the greenlet workaround from @Kanzakisol since it did not seem to be necessary anymore.

Lastly, [since the ZeroNet devs started signing their commits](https://github.com/HelloZeroNet/ZeroNet/issues/738)([new key](https://github.com/HelloZeroNet/ZeroNet/issues/759)), I added a mechanism to verify the signatures before running the program.